### PR TITLE
Handle missing state param

### DIFF
--- a/django_gapps_oauth2_login/tests.py
+++ b/django_gapps_oauth2_login/tests.py
@@ -226,6 +226,22 @@ class TestGappsOauth2Login(unittest.TestCase):
 
         user.delete()
 
+    def test_auth_required_missing_state(self):
+        request = HttpRequest()
+        request.META = {
+            'SERVER_NAME': 'testserver',
+            'SERVER_PORT': 80,
+            'REMOTE_ADDR': '6457.255.345.123',
+        }
+        request.REQUEST = {
+            'state': 'abcd',
+        }
+
+        response = auth_required(request)
+
+        self.assertEqual(response.content, 'state parameter is required')
+
+
     def test_auth_required_invalid_state(self):
         user = User(first_name='vivek', last_name='chand',
                     username='vivek@rajnikanth.com')

--- a/django_gapps_oauth2_login/views.py
+++ b/django_gapps_oauth2_login/views.py
@@ -49,6 +49,10 @@ def login_begin(request):
 
 
 def auth_required(request):
+    if not request.REQUEST.get('state'):
+        return HttpResponseBadRequest('state parameter is '
+                                      'required')
+
     if not xsrfutil.validate_token(settings.SECRET_KEY,
                                    request.REQUEST['state'],
                                    request.user):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ Run testcases, python manage.py test django_gapps_oauth2_login
 """
 
 setup(name='django_gapps_oauth2_login',
-      version='0.9.7.6',
+      version='0.9.7.7',
       description='Django Google Apps Oauth2 Login',
       long_description = long_description,
       author='Vivek Chand',


### PR DESCRIPTION
throw a bad request if state param is missing in oauth2 handshake