### PR TITLE
Issue 9750 check response status

### DIFF
--- a/django_gapps_oauth2_login/tests.py
+++ b/django_gapps_oauth2_login/tests.py
@@ -621,7 +621,7 @@ class TestGappsOauth2Login(unittest.TestCase):
         mock_request_get.side_effect = requests.RequestException('foo')
         value = utils.get_profile('some url')
 
-        assert value == {'error': 'Access Denied!There was an unkown error '
+        assert value == {'error': 'Access Denied!There was an unknown error '
                                   'when trying to access the GApps profile.'}
 
     @patch.object(json, 'loads')

--- a/django_gapps_oauth2_login/tests.py
+++ b/django_gapps_oauth2_login/tests.py
@@ -608,35 +608,3 @@ class TestGappsOauth2Login(unittest.TestCase):
 
         details = utils.get_profile("some url")
         assert details == return_value
-
-    @patch.object(json, 'loads')
-    @patch.object(requests, 'get')
-    def test_get_profile_invalid(self, mock_request_get, json_loads):
-        return_value = {
-            'valid_property_name': 'valid_property_value'
-        }
-
-        json_loads.return_value = return_value
-
-        mock_request_get.side_effect = requests.RequestException('foo')
-        value = utils.get_profile('some url')
-
-        assert value == {'error': 'Access Denied!There was an unknown error '
-                                  'when trying to access the GApps profile.'}
-
-    @patch.object(json, 'loads')
-    @patch.object(requests, 'get')
-    def test_get_profile_invalid_status(self, mock_request_get, json_loads):
-        get_return_value = MagicMock(
-            content='{"valid_property_name": "valid_property_value"}',
-            status_code=400
-        )
-
-        mock_request_get.return_value = get_return_value
-
-        return_value = {'error': 'Access Denied! GApps returned a status 400'}
-
-        details = utils.get_profile("some url")
-        assert details == return_value
-
-

--- a/django_gapps_oauth2_login/tests.py
+++ b/django_gapps_oauth2_login/tests.py
@@ -594,8 +594,10 @@ class TestGappsOauth2Login(unittest.TestCase):
     @patch.object(requests, 'get')
     def test_get_profile_valid(self, mock_request_get, json_loads):
 
-        get_return_value = MagicMock(content='{"valid_property_name": ' \
-                                        '"valid_property_value"}' )
+        get_return_value = MagicMock(
+            content='{"valid_property_name": "valid_property_value"}',
+            status_code=200
+        )
         mock_request_get.return_value = get_return_value
 
         return_value = {
@@ -622,5 +624,19 @@ class TestGappsOauth2Login(unittest.TestCase):
         assert value == {'error': 'Access Denied!There was an unkown error '
                                   'when trying to access the GApps profile.'}
 
+    @patch.object(json, 'loads')
+    @patch.object(requests, 'get')
+    def test_get_profile_invalid_status(self, mock_request_get, json_loads):
+        get_return_value = MagicMock(
+            content='{"valid_property_name": "valid_property_value"}',
+            status_code=400
+        )
+
+        mock_request_get.return_value = get_return_value
+
+        return_value = {'error': 'Access Denied! GApps returned a status 400'}
+
+        details = utils.get_profile("some url")
+        assert details == return_value
 
 

--- a/django_gapps_oauth2_login/utils.py
+++ b/django_gapps_oauth2_login/utils.py
@@ -22,36 +22,14 @@ def function_importer(func):
 
 def get_profile(url):
     try:
-        content = requests.get(url).content
-        return json.loads(content)
+        response = requests.get(url)
 
-    # except requests.ConnectionError:
-    #     return {
-    #         'error': ('Access Denied! '
-    #                   'There was a connection error when trying '
-    #                   'to access the GApps profile')
-    #     }
-    #
-    # except requests.HTTPError:
-    #     return {
-    #         'error': ('Access Denied!'
-    #                   'The request to Google API returned an '
-    #                   'invalid HTTP response')
-    #     }
-    #
-    # except requests.Timeout:
-    #     return {
-    #         'error': ('Access Denied!'
-    #                   'The connection timed out while trying '
-    #                   'to access the GApps profile')
-    #     }
-    #
-    # except requests.TooManyRedirects:
-    #     return {
-    #         'error': ('Access Denied!'
-    #                   'The requests to the GApps profile '
-    #                   'caused too many redirects')
-    #     }
+        if response.status_code != 200:
+            return {'error': 'Access Denied! GApps returned a'
+                             ' status {0}'.format(response.status_code)}
+
+        content = response.content
+        return json.loads(content)
 
     except requests.RequestException:
         return {'error': ('Access Denied!'

--- a/django_gapps_oauth2_login/utils.py
+++ b/django_gapps_oauth2_login/utils.py
@@ -33,7 +33,7 @@ def get_profile(url):
 
     except requests.RequestException:
         return {'error': ('Access Denied!'
-                          'There was an unkown error when trying to '
+                          'There was an unknown error when trying to '
                           'access the GApps profile.')}
 
     except ValueError:

--- a/django_gapps_oauth2_login/utils.py
+++ b/django_gapps_oauth2_login/utils.py
@@ -21,23 +21,14 @@ def function_importer(func):
 
 
 def get_profile(url):
-    try:
-        response = requests.get(url)
+    response = requests.get(url)
 
-        if response.status_code != 200:
-            return {'error': 'Access Denied! GApps returned a'
-                             ' status {0}'.format(response.status_code)}
+    if response.status_code != 200:
+        return {'error': 'Access Denied! GApps'
+                         ' returned a status {0}'.format(response.status_code)}
 
-        content = response.content
-        return json.loads(content)
-
-    except requests.RequestException:
-        return {'error': ('Access Denied!'
-                          'There was an unknown error when trying to '
-                          'access the GApps profile.')}
-    except ValueError:
-        return {'error': ('Access Denied!'
-                          'GApps returned an invalid response.')}
+    content = response.content
+    return json.loads(content)
 
 
 def _extract_user_details(oauth2_response):

--- a/django_gapps_oauth2_login/utils.py
+++ b/django_gapps_oauth2_login/utils.py
@@ -21,14 +21,56 @@ def function_importer(func):
 
 
 def get_profile(url):
-    return json.loads(requests.get(url).content)
+    try:
+        content = requests.get(url).content
+        return json.loads(content)
 
+    # except requests.ConnectionError:
+    #     return {
+    #         'error': ('Access Denied! '
+    #                   'There was a connection error when trying '
+    #                   'to access the GApps profile')
+    #     }
+    #
+    # except requests.HTTPError:
+    #     return {
+    #         'error': ('Access Denied!'
+    #                   'The request to Google API returned an '
+    #                   'invalid HTTP response')
+    #     }
+    #
+    # except requests.Timeout:
+    #     return {
+    #         'error': ('Access Denied!'
+    #                   'The connection timed out while trying '
+    #                   'to access the GApps profile')
+    #     }
+    #
+    # except requests.TooManyRedirects:
+    #     return {
+    #         'error': ('Access Denied!'
+    #                   'The requests to the GApps profile '
+    #                   'caused too many redirects')
+    #     }
+
+    except requests.RequestException:
+        return {'error': ('Access Denied!'
+                          'There was an unkown error when trying to '
+                          'access the GApps profile.')}
+
+    except ValueError:
+        return {'error': ('Access Denied!'
+                          'GApps returned an invalid response.')}
 
 def _extract_user_details(oauth2_response):
     email = fullname = first_name = last_name = None
     access_token = oauth2_response['access_token']
     profile = get_profile('https://www.googleapis.com/oauth2/v1/'
                           'userinfo?alt=json&access_token=%s' % access_token)
+
+    if profile.get('error'):
+        return profile
+
     fullname = profile.get('name')
     email = profile.get('email')
     if ' ' in fullname:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ Run testcases, python manage.py test django_gapps_oauth2_login
 """
 
 setup(name='django_gapps_oauth2_login',
-      version='0.9.7.7',
+      version='0.9.7.8',
       description='Django Google Apps Oauth2 Login',
       long_description = long_description,
       author='Vivek Chand',


### PR DESCRIPTION
Issue: ERROR:django.request Internal Server Error: /oauth2/oauth2callback/ 

Explanation:
The Gapps library uses requests.get() to retrieve profile data from the google apps server.
There is no proper error handling for when requests.get() does not return a 200 status code.

Solution:
Add error handling when gapps does not respond with a 200 response.

Code changes:
django_gapps_oauth2_login/utils.py
django_gapps_oauth2_login/tests.py