### PR TITLE
Issue: ERROR:django.request Internal Server Error: /oauth2/oauth2call…

### DIFF
--- a/django_gapps_oauth2_login/utils.py
+++ b/django_gapps_oauth2_login/utils.py
@@ -40,6 +40,10 @@ def _extract_user_details(oauth2_response):
     if profile.get('error'):
         return profile
 
+    required_keys = ['name', 'email', 'hd']
+    if not all(key in profile for key in required_keys):
+        return {'error': 'Access Denied! GApps did not return required keys'}
+
     fullname = profile.get('name')
     email = profile.get('email')
     if ' ' in fullname:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ Run testcases, python manage.py test django_gapps_oauth2_login
 """
 
 setup(name='django_gapps_oauth2_login',
-      version='0.9.7.8',
+      version='0.9.7.9',
       description='Django Google Apps Oauth2 Login',
       long_description = long_description,
       author='Vivek Chand',


### PR DESCRIPTION
…back/

Explanation:
For some reason, Gapps is not returning a name when it retrieves a user profile.
Profile is expected to have a name key so this breaks the GApps login mechanism.

Solution:
Not sure why GApps is not returning name, seems to be an edge case.
Handle it gracefully, for now. Explore it further if recurring.

Code changes:
Check for keys before processing response from GApps, handle gracefully if not present.
django_gapps_oauth2_login/django_gapps_oauth2_login/utils.py

Update version:
setup.py