### PR TITLE
fix import of importlib

### DIFF
--- a/django_gapps_oauth2_login/utils.py
+++ b/django_gapps_oauth2_login/utils.py
@@ -3,7 +3,7 @@ import json
 import requests
 import httplib2
 from oauth2client.client import AccessTokenCredentials
-from django.utils import importlib
+import importlib
 from BeautifulSoup import BeautifulSoup
 
 from .models import CredentialsModel


### PR DESCRIPTION
Django has removed this from utils, this was intended for older
python versions